### PR TITLE
feat - Add circle collider, circle renderer

### DIFF
--- a/Engine/Components/Base/GameObject.h
+++ b/Engine/Components/Base/GameObject.h
@@ -38,7 +38,7 @@ public:
 
 		for (Component* mono : monoBehaviors)
 		{
-			if (typeid(*mono) == typeid(T))
+			if (typeid(MonoBehavior) == typeid(T))
 			{
 				return static_cast<T*>(static_cast<Component*>(mono));
 			}
@@ -78,7 +78,7 @@ public:
 	void SetQueryInterface(IGameObjectQuery* q);
 
 	Transform& GetTransform();
-
+	
 protected:
 	EngineData::RenderLayer renderLayer = EngineData::RenderLayer::None;
 	IGameObjectQuery* query = nullptr;
@@ -93,5 +93,5 @@ private:
 	std::vector<Component*> components;			// 컴포넌트를 담는 컨테이너
 	std::queue<Component*> startQueue;			// start를 실행하지 않은 컴포넌트 모음
 	bool shouldRemove = false;					// 해당 오브젝트가 다음 프레임에 제거될 대상인지 확인하는 변수 ( 제거예정이면 true )
-	bool isActiveInScene = true;					// 해당 오브젝트가 이번 프레임에 생성되었는지 확인하는 변수 ( 생성된 후 다음 프레임에 false로 전환 )
+	bool isActiveInScene = true;				// 해당 오브젝트가 이번 프레임에 생성되었는지 확인하는 변수 ( 생성된 후 다음 프레임에 false로 전환 )
 };

--- a/Engine/Components/Collision/CircleCollider.cpp
+++ b/Engine/Components/Collision/CircleCollider.cpp
@@ -1,0 +1,116 @@
+﻿#include "CircleCollider.h"
+#include "Components/Base/GameObject.h"
+#include <algorithm>
+
+CircleCollider::CircleCollider()
+{
+	collider = this;
+	type = ColliderType::Circle;
+}
+
+void CircleCollider::FixedUpdate(const std::vector<CollisionComponent*>& others, std::vector<CollisionInfo>& outInfos)
+{
+	for (auto it = others.begin(); it != others.end(); it++)
+	{
+		if ((*it)->owner == this->owner) continue;
+
+		ICollider* other = dynamic_cast<ICollider*>((*it)->collider);
+		if (other == nullptr) continue;
+
+		CollisionInfo outInfo{ nullptr, nullptr, Vector2::Zero(), 0 }; // 충돌 정보
+		if (CheckCollision(other, outInfo))
+		{
+			outInfos.push_back(outInfo);
+		}
+	}
+}
+
+ColliderType CircleCollider::GetColliderType()
+{
+	return type;
+}
+
+Vector2 CircleCollider::GetCenter() const
+{
+	return Vector2(owner->GetTransform().GetPosition().x, owner->GetTransform().GetPosition().y);
+}
+
+bool CircleCollider::CheckCollision(ICollider* other, CollisionInfo& outCollisionInfo)
+{
+	ColliderType type = other->GetColliderType();
+	switch (type)
+	{
+	case Circle:
+		return CheckCollisionWithCircle(other, outCollisionInfo);
+	case AABB:
+		break;
+	default:
+		break;
+	}
+
+	return false;
+}
+
+bool CircleCollider::CheckCollisionWithCircle(ICollider* other, CollisionInfo& outCollisionInfo)
+{
+	CircleCollider* otherCircle = static_cast<CircleCollider*>(other);
+	if (!otherCircle) return false;
+
+	float aRadius = GetRadius();
+	float bRadius = otherCircle->GetRadius();
+
+	Vector2 aCenter = GetCenter();
+	Vector2 bCenter = otherCircle->GetCenter();
+
+	bool isColliding = (bCenter.x - aCenter.x) * (bCenter.x - aCenter.x) + (bCenter.y - aCenter.y) * (bCenter.y - aCenter.y) <= (aRadius + bRadius) * (aRadius + bRadius);
+
+	if (isColliding)
+	{
+		// 침투한 길이 
+
+		Vector2 delta = bCenter - aCenter;
+
+		outCollisionInfo.normal = (aCenter - bCenter).Normalize();
+		outCollisionInfo.penetrationDepth = 1; // 임시 
+
+		outCollisionInfo.a = dynamic_cast<CollisionComponent*>(this);
+		outCollisionInfo.b = dynamic_cast<CollisionComponent*>(otherCircle);
+
+		//std::cout << "[Collision] Normal: ("
+		//	<< outCollisionInfo.normal.x << ", "
+		//	<< outCollisionInfo.normal.y << "), Depth: "
+		//	<< outCollisionInfo.penetrationDepth << "\n";
+	}
+
+	return isColliding;
+}
+
+void CircleCollider::OnCreate()
+{
+
+}
+
+void CircleCollider::OnStart()
+{
+	debugCircle = owner->AddComponent<CircleComponent>();
+	debugCircle->SetRadius(radius);
+	debugCircle->SetIsShow(true);
+}
+
+void CircleCollider::OnDestroy()
+{
+}
+
+void CircleCollider::SetRadius(float radius)
+{
+	this->radius = radius;
+	if (debugCircle)
+	{
+		debugCircle->SetRadius(radius);
+	}
+}
+
+float CircleCollider::GetRadius() const
+{
+	return radius;
+}

--- a/Engine/Components/Collision/CircleCollider.h
+++ b/Engine/Components/Collision/CircleCollider.h
@@ -1,0 +1,32 @@
+﻿/// 2025.07.28 | 작성자 : 이성호
+/// 원 충돌 체크하는 충돌 컴포넌트
+/// 작성 기준 원 vs 원 체크만 있음.
+
+#pragma once
+#include "Components/Collision/CollisionComponent.h"
+#include "Math/Vector2.h"
+#include "Components/Rendering/CircleComponent.h"
+class CircleCollider : public CollisionComponent, ICollider
+{
+public:
+	CircleCollider();
+	void FixedUpdate(const std::vector<CollisionComponent*>& others, std::vector<CollisionInfo>& outInfos) override;
+
+	ColliderType GetColliderType() override;
+	Vector2 GetCenter() const override;
+
+	// 충돌 확인용 인터페이스
+	bool CheckCollision(ICollider* other, CollisionInfo& outCollisionInfo) override;
+	bool CheckCollisionWithCircle(ICollider* other, CollisionInfo& outCollisionInfo);
+
+	void OnCreate() override;
+	void OnStart() override;
+	void OnDestroy() override;
+	void SetRadius(float radius);
+	float GetRadius() const;
+
+private:
+	CircleComponent* debugCircle{};
+	float radius = 1.0f; // 지름
+	float size = 1.0f;
+};

--- a/Engine/Components/Rendering/CircleComponent.cpp
+++ b/Engine/Components/Rendering/CircleComponent.cpp
@@ -1,0 +1,44 @@
+﻿#include "CircleComponent.h"
+#include "Platform/D2DRenderManager.h"
+#include "Components/Base/GameObject.h"
+
+void CircleComponent::OnStart()
+{
+	renderManager->CreateBrush(D2D1::ColorF::Green, &brush);
+}
+
+void CircleComponent::OnDestroy()
+{
+	if (brush)
+	{
+		brush->Release();
+	}
+}
+
+void CircleComponent::Render(D2DRenderManager* render)
+{
+	if (!isShow) return;
+
+	if (brush)
+	{
+		D2D1_MATRIX_3X2_F mat = owner->GetTransform().GetFinalMatrix();
+
+		render->SetBitmapTransform(mat);
+		render->DrawCircle(brush, radius, 1.0f, strokeStyle);
+	}
+}
+
+void CircleComponent::SetRadius(float radius)
+{
+	this->radius = radius;
+}
+
+void CircleComponent::SetStyle(ID2D1StrokeStyle* style)
+{
+	this->strokeStyle = style;
+}
+
+void CircleComponent::SetIsShow(bool value)
+{
+	isShow = value;
+}

--- a/Engine/Components/Rendering/CircleComponent.h
+++ b/Engine/Components/Rendering/CircleComponent.h
@@ -1,0 +1,27 @@
+﻿#pragma once
+#include "Components/Rendering/RenderComponent.h"
+
+/// 25.07.28 | 작성자 이성호
+/// 원 모양을 그리는 컴포넌트
+/// radius 크기의 원을 그린다.
+
+class CircleComponent : public RenderComponent
+{
+public:
+	void OnStart() override;
+	void OnDestroy() override;
+
+	void Render(D2DRenderManager* render) override;
+	void SetRadius(float radius);
+	void SetStyle(ID2D1StrokeStyle* style);
+	void SetIsShow(bool value);
+
+private:
+	ID2D1SolidColorBrush* brush{};
+	ID2D1StrokeStyle* strokeStyle = (ID2D1StrokeStyle*)0;
+
+	float radius{};
+
+	bool isShow = false;
+};
+

--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -333,6 +333,8 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Components\Collision\CircleCollider.h" />
+    <ClInclude Include="Components\Rendering\CircleComponent.h" />
     <ClInclude Include="Components\Base\ActiveComponent.h" />
     <ClInclude Include="Components\Base\MonoBehavior.h" />
     <ClInclude Include="Components\Base\BaseObject.h" />
@@ -391,6 +393,8 @@
     <ClInclude Include="Math\Vector2.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Components\Collision\CircleCollider.cpp" />
+    <ClCompile Include="Components\Rendering\CircleComponent.cpp" />
     <ClCompile Include="Components\Base\BaseObject.cpp" />
     <ClCompile Include="Components\Base\Component.cpp" />
     <ClCompile Include="Components\Rendering\RenderComponent.cpp" />

--- a/Engine/Engine.vcxproj.filters
+++ b/Engine/Engine.vcxproj.filters
@@ -218,6 +218,12 @@
     </ClInclude>
     <ClInclude Include="framework.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="Components\Collision\CircleCollider.h">
+      <Filter>Components\Collider</Filter>
+    </ClInclude>
+    <ClInclude Include="Components\Rendering\CircleComponent.h">
+      <Filter>Components\Rendering</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Application\Application.cpp">
@@ -337,6 +343,12 @@
     <ClCompile Include="MyD2DEngine.cpp" />
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="Components\Rendering\RenderComponent.cpp">
+      <Filter>Components\Rendering</Filter>
+    </ClCompile>
+    <ClCompile Include="Components\Collision\CircleCollider.cpp">
+      <Filter>Components\Collider</Filter>
+    </ClCompile>
+    <ClCompile Include="Components\Rendering\CircleComponent.cpp">
       <Filter>Components\Rendering</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Engine/Platform/D2DRenderManager.cpp
+++ b/Engine/Platform/D2DRenderManager.cpp
@@ -99,6 +99,11 @@ void D2DRenderManager::DrawRectangle(D2D1_RECT_F& rect, ID2D1Brush* brush, FLOAT
 	m_d2dDeviceContext->DrawRectangle(rect, brush, width, strokeStyle);
 }
 
+void D2DRenderManager::DrawCircle(ID2D1Brush* brush, FLOAT radius, FLOAT width, ID2D1StrokeStyle* strokeStyle)
+{
+	m_d2dDeviceContext->DrawEllipse({{0, 0}, radius, radius}, brush, width, strokeStyle); // NOTE: 만약 타원이 필요하면 raidus를 쪼개면 됨., 위치가 0인 이유는 SetTransform으로 위치를 옮기기 때문
+}
+
 void D2DRenderManager::PrintText(const wchar_t* str, float left, float top, bool isWorld)
 {
 	if (!m_d2dDeviceContext || !m_pBrush) return;

--- a/Engine/Platform/D2DRenderManager.h
+++ b/Engine/Platform/D2DRenderManager.h
@@ -23,7 +23,7 @@ public:
 
 	void CreateBrush(const D2D1::ColorF& color, ID2D1SolidColorBrush** pBrush);
 	void DrawRectangle(D2D1_RECT_F& rect, ID2D1Brush* brush, FLOAT width = 1.0f, ID2D1StrokeStyle* strokeStyle = (ID2D1StrokeStyle*)0);
-
+	void DrawCircle(ID2D1Brush* brush, FLOAT radius = 1.0f, FLOAT width = 1.0f, ID2D1StrokeStyle* strokeStyle = (ID2D1StrokeStyle*)0);
 
 	/// <summary>
 	/// WIC를 통해 이미지를 ID2D1Bitmap1**로 반환하는 함수

--- a/Engine/Systems/CollisionSystem.cpp
+++ b/Engine/Systems/CollisionSystem.cpp
@@ -113,34 +113,38 @@ void CollisionSystem::CallEvent(CollisionComponent* a, CollisionComponent* b, co
 
 	auto DoCall = [&](GameObject* caller, GameObject* target, bool trigger)
 		{
+			MonoBehavior* mono = caller->GetComponent<MonoBehavior>();
 			if (trigger)
 			{
-				if (type == "Enter") // NOTE: 호출하기
+
+				if (!mono) return;
+
+				if (type == "Enter") // NOTE: 현재 monobehaivior중 하나만 호출됨, 모두 호출되게 수정하기
 				{
-					// caller->OnTriggerEnter(target);
+					mono->OnTriggerEnter(target);
 				}
 				else if (type == "Stay")
 				{
-					// caller->OnTriggerStay(target);
+					mono->OnTriggerStay(target);
 				}
 				else if (type == "Exit")
 				{
-					// caller->OnTriggerExit(target);
+					mono->OnTriggerExit(target);
 				}
 			}
 			else
 			{
 				if (type == "Enter")
 				{
-					// caller->OnColliderEnter(target);
+					mono->OnColliderEnter(target);
 				}
 				else if (type == "Stay")
 				{
-					// caller->OnColliderStay(target);
+					mono->OnColliderStay(target);
 				}
 				else if (type == "Exit")
 				{
-					// caller->OnColliderExit(target);
+					mono->OnColliderExit(target);
 				}
 			}
 		};

--- a/Engine/Systems/CollisionSystem.h
+++ b/Engine/Systems/CollisionSystem.h
@@ -24,7 +24,7 @@ struct CollisionPair
 class CollisionSystem : public Singleton<CollisionSystem>
 {
 public:
-	friend class  Singleton<CollisionSystem>;
+	friend class Singleton<CollisionSystem>;
 
 	void Register(CollisionComponent* comp);
 	void UnRegister(CollisionComponent* comp);

--- a/WorkSpace/LSH/LSH.vcxproj
+++ b/WorkSpace/LSH/LSH.vcxproj
@@ -335,11 +335,13 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Application\Game.cpp" />
+    <ClCompile Include="TestColliderApp\Scripts\DummyCircleCollider.cpp" />
     <ClCompile Include="TestColliderApp\App\TestColliderApp.cpp" />
     <ClCompile Include="TestColliderApp\Scenes\CircleColliderScene.cpp" />
     <ClCompile Include="TestColliderApp\Scripts\TestCircleCollider.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="TestColliderApp\Scripts\DummyCircleCollider.h" />
     <ClInclude Include="TestColliderApp\App\TestColliderApp.h" />
     <ClInclude Include="TestColliderApp\Scenes\CircleColliderScene.h" />
     <ClInclude Include="TestColliderApp\Scripts\TestCircleCollider.h" />

--- a/WorkSpace/LSH/LSH.vcxproj.filters
+++ b/WorkSpace/LSH/LSH.vcxproj.filters
@@ -11,6 +11,9 @@
     <ClCompile Include="TestColliderApp\Scripts\TestCircleCollider.cpp">
       <Filter>Scripts</Filter>
     </ClCompile>
+    <ClCompile Include="TestColliderApp\Scripts\DummyCircleCollider.cpp">
+      <Filter>Scripts</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TestColliderApp\App\TestColliderApp.h">
@@ -20,6 +23,9 @@
       <Filter>Scene</Filter>
     </ClInclude>
     <ClInclude Include="TestColliderApp\Scripts\TestCircleCollider.h">
+      <Filter>Scripts</Filter>
+    </ClInclude>
+    <ClInclude Include="TestColliderApp\Scripts\DummyCircleCollider.h">
       <Filter>Scripts</Filter>
     </ClInclude>
   </ItemGroup>

--- a/WorkSpace/LSH/TestColliderApp/Scenes/CircleColliderScene.cpp
+++ b/WorkSpace/LSH/TestColliderApp/Scenes/CircleColliderScene.cpp
@@ -1,13 +1,19 @@
 ﻿#include "CircleColliderScene.h"
 #include "TestColliderApp/Scripts/TestCircleCollider.h"
+#include "TestColliderApp/Scripts/DummyCircleCollider.h"
 
 void TestCollider::CircleColliderScene::OnEnterImpl()
 {
 	testCircle = new GameObject();
-	testCircle->SetName("Cirlce");
+	testCircle->SetName("Test Cirlce");
+	testCircle->AddComponent<TestCircleCollider>();
 	AddGameObject(testCircle);
 
-	testCircle->AddComponent<TestCircleCollider>();
+
+	dummyCircle = new GameObject();
+	dummyCircle->SetName("Dummy Cirlce");
+	dummyCircle->AddComponent<DummyCircleCollider>();
+	AddGameObject(dummyCircle);
 }
 
 void TestCollider::CircleColliderScene::OnExitImpl()

--- a/WorkSpace/LSH/TestColliderApp/Scenes/CircleColliderScene.h
+++ b/WorkSpace/LSH/TestColliderApp/Scenes/CircleColliderScene.h
@@ -12,5 +12,6 @@ namespace TestCollider
 
 	private:
 		GameObject* testCircle{};
+		GameObject* dummyCircle{};
 	};
 }

--- a/WorkSpace/LSH/TestColliderApp/Scripts/DummyCircleCollider.cpp
+++ b/WorkSpace/LSH/TestColliderApp/Scripts/DummyCircleCollider.cpp
@@ -1,0 +1,55 @@
+﻿#include "DummyCircleCollider.h"
+#include "Components/Base/GameObject.h"
+#include "Platform/Input.h"
+
+void DummyCircleCollider::OnCreate()
+{
+	owner->GetTransform().SetUnityCoords(true);
+
+	circle = owner->AddComponent<CircleCollider>();
+	circle->SetRadius(20.0f);
+
+	input = owner->AddComponent<InputSystem>();
+}
+
+void DummyCircleCollider::OnStart()
+{
+}
+
+void DummyCircleCollider::OnFixedUpdate()
+{
+}
+
+void DummyCircleCollider::OnUpdate()
+{
+	HandleInput();
+	//owner->GetTransform().SetPosition(Input::MouseX, Input::MouseY);
+	// std::cout << "dummy position :::: " << owner->GetTransform().GetPosition().x << ", " << owner->GetTransform().GetPosition().y << std::endl;
+}
+
+void DummyCircleCollider::OnDestroy()
+{
+}
+
+void DummyCircleCollider::OnColliderEnter(GameObject* collider)
+{
+	std::cout << ">>> Dummy 충돌시작 >>>" << std::endl;
+}
+
+void DummyCircleCollider::OnColliderStay(GameObject* collider)
+{
+	std::cout << ">>> Dummy 충돌 중 >>>" << std::endl;
+}
+
+void DummyCircleCollider::OnColliderExit(GameObject* collider)
+{
+	std::cout << ">>> Dummy 충돌 종료 >>>" << std::endl;
+}
+
+void DummyCircleCollider::HandleInput()
+{
+	if (input->IsKeyDown('W')) owner->GetTransform().Translate({ 0, 1 });
+	if (input->IsKeyDown('A')) owner->GetTransform().Translate({ -1, 0 });
+	if (input->IsKeyDown('S')) owner->GetTransform().Translate({ 0, -1 });
+	if (input->IsKeyDown('D')) owner->GetTransform().Translate({ 1, 0 });
+}

--- a/WorkSpace/LSH/TestColliderApp/Scripts/DummyCircleCollider.h
+++ b/WorkSpace/LSH/TestColliderApp/Scripts/DummyCircleCollider.h
@@ -1,12 +1,13 @@
 ﻿/// 25.07.28 | 작성자 이성호
-/// 콜라이더 충돌 대상 오브젝트의 MonoBehavior
+/// 조종 가능한 콜라이더 충돌 대상 오브젝트의 MonoBehavior
 
 #pragma once
 #include "Components/Base/MonoBehavior.h"
 #include "Components/Rendering/TextRenderer.h"
 #include "Components/Collision/CircleCollider.h"
+#include "Components/Logic/InputSystem.h"
 
-class TestCircleCollider : public MonoBehavior
+class DummyCircleCollider : public MonoBehavior
 {
 public:
 	void OnCreate() override;
@@ -20,6 +21,8 @@ public:
 	void OnColliderExit(GameObject* collider) override;
 
 private:
+	void HandleInput();
+
 	CircleCollider* circle{};
-	TextRenderer* infoText{};
+	InputSystem* input{};
 };

--- a/WorkSpace/LSH/TestColliderApp/Scripts/TestCircleCollider.cpp
+++ b/WorkSpace/LSH/TestColliderApp/Scripts/TestCircleCollider.cpp
@@ -8,10 +8,16 @@ void TestCircleCollider::OnCreate()
 
 void TestCircleCollider::OnStart()
 {
+	// info text
 	infoText = owner->AddComponent<TextRenderer>();
 	infoText->SetViewportPosition(0.5f, 0.5f);
 
 	infoText->SetText(L"- 콜라이더 테스트 씬 - ");
+	infoText->SetWorldObject(true);
+
+	// circle
+	circle = owner->AddComponent<CircleCollider>();
+	circle->SetRadius(10.0f);
 }
 
 void TestCircleCollider::OnFixedUpdate()
@@ -24,4 +30,19 @@ void TestCircleCollider::OnUpdate()
 
 void TestCircleCollider::OnDestroy()
 {
+}
+
+void TestCircleCollider::OnColliderEnter(GameObject* collider)
+{
+	std::cout << "--- Test Circle 충돌시작 ---"<< std::endl;
+}
+
+void TestCircleCollider::OnColliderStay(GameObject* collider)
+{
+	std::cout << "--- Test Circle 충돌 중 ---"<< std::endl;
+}
+
+void TestCircleCollider::OnColliderExit(GameObject* collider)
+{
+	std::cout << "--- Test Circle 충돌 종료---"<< std::endl;
 }


### PR DESCRIPTION
### 추가
1. 원 콜라이더
2. 원 그리는 컴포넌트

### 수정
1. 게임 오브젝트의 monoBehavior 타입비교 코드 오류 수정
2. RenderManager에 원 그리는 코드 추가

### 주의 사항
현재 원 충돌은 가장 먼저 추가한 monobehvior만 감지함.
추후 수정이 필요하면 모든 monobehavior를 참조할 수 있는 함수를 만들고
ColliderSystem에서 참조하여 envent를 호출할 수 있게 수정할 것.