### PR TITLE
마우스 윈도우 창에서 벗어날때 이벤트 처리 추가

### DIFF
--- a/Engine/Application/Application.cpp
+++ b/Engine/Application/Application.cpp
@@ -192,7 +192,10 @@ void Application::MessageProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 	case WM_MBUTTONDOWN:
 	case WM_MBUTTONUP:
 	case WM_MOUSEWHEEL:
-		Input::ProcessMouseMessage(msg, wParam, lParam);
+		Input::ProcessMouseMessage(hWnd, msg, wParam, lParam);
+		break;
+	case WM_MOUSELEAVE:
+		Input::ResetMouseOnOutOfBounds();
 		break;
 	default:
 		break;

--- a/Engine/Platform/Input.cpp
+++ b/Engine/Platform/Input.cpp
@@ -1,5 +1,6 @@
 ﻿#include "pch.h"
 #include "Input.h"
+#include "../Datas/EngineData.h"
 
 float Input::MouseX = 0.0f;
 float Input::MouseY = 0.0f;
@@ -11,22 +12,29 @@ bool Input::leftButtonDown = false;
 bool Input::rightButtonDown = false;
 bool Input::middleButtonDown = false;
 
-void Input::Update() {
+bool Input::IsTrackingMouse = false;
+bool Input::IsMouseInside = false;
+
+void Input::Update() 
+{
     memcpy_s(prevState, sizeof(prevState), currState, sizeof(currState));
     for (int i = 0; i < 256; i++) {
         currState[i] = GetAsyncKeyState(i);
     }
 }
 
-bool Input::IsKeyDown(int vKey) {
+bool Input::IsKeyDown(int vKey) 
+{
     return (currState[vKey] & 0x8000) != 0;
 }
 
-bool Input::IsKeyPressed(int vKey) {
+bool Input::IsKeyPressed(int vKey) 
+{
     return (!(prevState[vKey] & 0x8000) && (currState[vKey] & 0x8000));
 }
 
-bool Input::IsKeyReleased(int vKey) {
+bool Input::IsKeyReleased(int vKey) 
+{
     return ((prevState[vKey] & 0x8000) && !(currState[vKey] & 0x8000));
 }
 
@@ -50,8 +58,19 @@ void Input::ResetMouseEventFrameState()
     wheelDelta = 0.0f;
 }
 
-void Input::ProcessMouseMessage(UINT message, WPARAM wParam, LPARAM lParam)
+void Input::ProcessMouseMessage(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
+    if (!IsTrackingMouse && message == WM_MOUSEMOVE)
+    {
+        TRACKMOUSEEVENT tme = {};
+        tme.cbSize = sizeof(tme);
+        tme.dwFlags = TME_LEAVE;
+        tme.hwndTrack = hwnd;
+        TrackMouseEvent(&tme);
+        IsTrackingMouse = true;
+        IsMouseInside = true;
+    }
+
     Input::MouseDeltaX = LOWORD(lParam) - Input::MouseX;
     Input::MouseDeltaY = HIWORD(lParam) - Input::MouseY;
     Input::MouseX = LOWORD(lParam);
@@ -76,4 +95,13 @@ void Input::ProcessMouseMessage(UINT message, WPARAM wParam, LPARAM lParam)
     // std::cout << "Left Button: " << leftButtonDown << std::boolalpha << std::endl;
     // std::cout << "Right Button: " << rightButtonDown << std::boolalpha << std::endl;
     // std::cout << "Middle Button: " << middleButtonDown << std::boolalpha << std::endl;
+}
+
+void Input::ResetMouseOnOutOfBounds()
+{
+    leftButtonDown = false;
+    rightButtonDown = false;
+    middleButtonDown = false;
+    IsTrackingMouse = false;
+    IsMouseInside = false;
 }

--- a/Engine/Platform/Input.h
+++ b/Engine/Platform/Input.h
@@ -23,12 +23,14 @@ public:
 	bool IsMouseDown(MouseButton button);
 
 #pragma region Mouse Event Params
-
 	// 매 프레임 시작시 마우스 이벤트 초기화 함수
 	static void ResetMouseEventFrameState();
 
-	// 윈도우 메세지 마우스 이벤트 처리 함수
-	static void ProcessMouseMessage(UINT message, WPARAM wParam, LPARAM lParam);
+	// 마우스가 화면밖에 나갔는지 확인하는 함수, 화면밖으로 나가면 모든 버튼 비활성화
+	static void ResetMouseOnOutOfBounds();
+
+	// 윈도우 메세지 마우스 이벤트 처리 함수 
+	static void ProcessMouseMessage(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 	static float MouseX;
 	static float MouseY;
@@ -40,6 +42,9 @@ public:
 	static bool leftButtonDown;
 	static bool rightButtonDown;
 	static bool middleButtonDown;
+
+	static bool IsTrackingMouse;
+	static bool IsMouseInside;
 #pragma endregion
 
 private:

--- a/WorkSpace/LSH/TestColliderApp/Scripts/DummyButton.cpp
+++ b/WorkSpace/LSH/TestColliderApp/Scripts/DummyButton.cpp
@@ -12,6 +12,10 @@ void DummyButton::OnStart()
 	button->SetRect(imageSize.width, imageSize.height);
 	button->AddOnClickEvent(std::bind(&DummyButton::OnClick, this));
 	button->AddOnClickEvent([&]() { SetValue(100); });
+
+	Vector2 start = Vector2::Zero();
+	Vector2 end = { 2,3 };
+	Vector2 dir = (end - start).Normalize();
 }
 
 void DummyButton::OnUpdate()


### PR DESCRIPTION
### 추가
1. WM_MOUSELEAVE 메세지 처리 추가
2. Input에 IsMouseInside 변수로 윈도우 창 안에 있는지 확인 할 수 있도록 변수 추가